### PR TITLE
In pushconfig, add unit to the default values of APPLY

### DIFF
--- a/pushconfig.sh
+++ b/pushconfig.sh
@@ -7,7 +7,7 @@
 
 FOLDER=""
 SCHEME="https"
-APPLY="backend,ainode"
+APPLY="backend,ainode,unit"
 VERSION="3.1.0"
 NO_DRY_RUN=true
 PRINT_SUBST=true


### PR DESCRIPTION
Pushconfig was not pushing to unit by default. Since now we have one unit with a config (castlab) it would be pertinent to do so instead of having to override it with -a 'ainode,backend,unit' each time. 
