### PR TITLE
Node rollout

### DIFF
--- a/reschedule_ainodes.sh
+++ b/reschedule_ainodes.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+# All ainode will be forces to reschedule on new nodes.
+# Old nodes will stay unschedulable until being removed
+# by cluster-autoscaler
+
+# Bash strict mode
+set -euo pipefail
+
+# Constants
+NORMAL='\e[0m'
+GREEN='\e[32m'
+YELLOW='\e[33m'
+
+# List of all kind of services to reconcile, the order is not important
+SERVICE_KINDS=(
+	"dynamicrouter"
+	"drmmanager"
+	"encrypt"
+	"dashmanifestgen"
+	"hlsmanifestgen"
+	"packager"
+	"xaudio"
+	"xcode"
+	"xsubtitles"
+	"segmenter"
+)
+
+# List of the ainodes to reconcile in order, written <name of the ainode>,<pod manager used>,<should the script wait after>
+AINODE_BATCH=(
+	"lbalancer-main,statefulset,true"
+	"dynamicrouter-main,statefulset,true"
+	"drmmanager-main,statefulset,true"
+	"encrypt-main,statefulset,true"
+	"dashmanifestgen-main,statefulset,false"
+	"hlsmanifestgen-main,statefulset,false"
+	"packager-main,statefulset,true"
+	"xaudio-main,statefulset,false"
+	"xsubtitles-main,statefulset,false"
+	"xcode-ska,statefulset,true"
+	"xcode-main,statefulset,false"
+	"xcode-backup,statefulset,true"
+	"segmenter-main,statefulset,false"
+)
+
+# Programm arguments parsing
+NAMESPACE=""
+WORKFLOWPOOL=""
+WAIT_TIME="120"
+AINODE_NODEGROUP_LABEL="group=ainodes-fix-group"
+
+function help() {
+	cat <<EOF
+Reschedule ainodes in a specific order.
+Usage : $0 -n NAMESPACE -w WORKFLOWPOOL [options]
+Mandatory arguments :
+    -n NAMESPACE         Set namespace of the workflowpool.
+    -w WORKFLOWPOOL :    Set the worflowpool name.
+Available options :
+    -h                   Display this help.
+    -t                   Override the default time in seconds between batch, by default 120.
+    -l                   Override Ainode nodegroup label, default is group=ainodes-fix-group.
+EOF
+}
+
+while getopts ":n:w:t:h" opt; do
+	case "$opt" in
+	h)
+		help
+		exit 0
+		;;
+	n)
+		NAMESPACE=$OPTARG
+		;;
+	w)
+		WORKFLOWPOOL=$OPTARG
+		;;
+	t)
+		WAIT_TIME=$OPTARG
+		;;
+	l)
+		AINODE_NODEGROUP_LABEL=$OPTARG
+		;;
+	*)
+		echo "Unsupported flag provided : $OPTARG".
+		help
+		exit 1
+		;;
+	esac
+done
+
+if [ "$NAMESPACE" == "" ]; then
+	echo "Namespace was not specified, aborting"
+	exit 1
+fi
+
+if [ "$WORKFLOWPOOL" == "" ]; then
+	echo "WorkflowPool was not specified, aborting"
+	exit 1
+fi
+
+if [ "$(kubectl get namespace ${NAMESPACE})" == "" ]; then
+	echo "Namespace ${NAMESPACE} does not exist, exiting."
+	exit 1
+fi
+
+echo -e "${GREEN}Cordon all ainode nodes ${NORMAL}"
+kubectl cordon -l ${AINODE_NODEGROUP_LABEL}
+
+# Reconciles ainodes in provider order
+echo -e "${GREEN}Starting restart of all ainodes...${NORMAL}"
+for ainode in "${AINODE_BATCH[@]}"; do
+	name=$(echo "${ainode}" | cut -d "," -f 1)
+	kind=$(echo "${ainode}" | cut -d "," -f 2)
+	wait=$(echo "${ainode}" | cut -d "," -f 3)
+	changed="false"
+
+	echo -e "${GREEN}Reconciling ainode ${name} ${NORMAL}"
+	kubectl rollout restart ${kind}/${WORKFLOWPOOL}-${name}-ainode -n "${NAMESPACE}"
+
+	# Wait for rollout to be completed
+	echo -e "${GREEN}Waiting for rollout to be complete ${NORMAL}"
+	kubectl rollout status "${kind}" "${WORKFLOWPOOL}-${name}-ainode" -n "${NAMESPACE}"
+
+	if [[ $wait == "true" ]]; then
+		echo -e "${YELLOW}Ainode needs to populate cache, waiting ${WAIT_TIME} seconds ${NORMAL}"
+		sleep "${WAIT_TIME}"
+	fi
+done

--- a/reschedule_ainodes.sh
+++ b/reschedule_ainodes.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# All ainode will be forces to reschedule on new nodes.
+# All pods on ainode nodegroups will be forced to reschedule on new nodes.
 # Old nodes will stay unschedulable until being removed
 # by cluster-autoscaler
 
@@ -11,35 +11,33 @@ NORMAL='\e[0m'
 GREEN='\e[32m'
 YELLOW='\e[33m'
 
-# List of all kind of services to reconcile, the order is not important
-SERVICE_KINDS=(
-	"dynamicrouter"
-	"drmmanager"
-	"encrypt"
-	"dashmanifestgen"
-	"hlsmanifestgen"
-	"packager"
-	"xaudio"
-	"xcode"
-	"xsubtitles"
-	"segmenter"
-)
-
-# List of the ainodes to reconcile in order, written <name of the ainode>,<pod manager used>,<should the script wait after>
-AINODE_BATCH=(
-	"lbalancer-main,statefulset,true"
-	"dynamicrouter-main,statefulset,true"
-	"drmmanager-main,statefulset,true"
-	"encrypt-main,statefulset,true"
-	"dashmanifestgen-main,statefulset,false"
-	"hlsmanifestgen-main,statefulset,false"
-	"packager-main,statefulset,true"
-	"xaudio-main,statefulset,false"
-	"xsubtitles-main,statefulset,false"
-	"xcode-ska,statefulset,true"
-	"xcode-main,statefulset,false"
-	"xcode-backup,statefulset,true"
-	"segmenter-main,statefulset,false"
+# List of the ainodes/mongo/backend to reschedule in order, written <name>,<suffix>,<pod manager used>,<should the script wait after>
+BATCH=(
+  "shield,,deployment,true"
+  "lbalancer-main,-ainode,statefulset,true"
+  "dynamicrouter-main,-ainode,statefulset,true"
+  "drmmanager-main,-ainode,statefulset,true"
+  "encrypt-main,-ainode,statefulset,true"
+  "dashmanifestgen-main,-ainode,statefulset,false"
+  "hlsmanifestgen-main,-ainode,statefulset,false"
+  "packager-main,-ainode,statefulset,true"
+  "xaudio-main,-ainode,statefulset,false"
+  "xsubtitles-main,-ainode,statefulset,false"
+  "xcode-ska,-ainode,statefulset,true"
+  "xcode-main,-ainode,statefulset,false"
+  "xcode-backup,-ainode,statefulset,true"
+  "segmenter-main,-ainode,statefulset,false"
+  "cache,-mongodb,statefulset,false"
+  "configuration,-mongodb,statefulset,false"
+  "dashmanifestgen-main,-backend,false"
+  "drmmanager-main,-backend,deployment,false"
+  "encrypt-main,-backend,deployment,false"
+  "hlsmanifestgen-main,-backend,deployment,false"
+  "packager-main,-backend,deployment,false"
+  "segmenter-main,-backend,deployment,false"
+  "xaudio-main,-backend,deployment,false"
+  "xcode-main,-backend,deployment,false"
+  "xsubtitles-main,-backend,deployment,false"
 )
 
 # Programm arguments parsing
@@ -49,7 +47,7 @@ WAIT_TIME="120"
 AINODE_NODEGROUP_LABEL="group=ainodes-fix-group"
 
 function help() {
-	cat <<EOF
+  cat <<EOF
 Reschedule ainodes in a specific order.
 Usage : $0 -n NAMESPACE -w WORKFLOWPOOL [options]
 Mandatory arguments :
@@ -63,44 +61,44 @@ EOF
 }
 
 while getopts ":n:w:t:h" opt; do
-	case "$opt" in
-	h)
-		help
-		exit 0
-		;;
-	n)
-		NAMESPACE=$OPTARG
-		;;
-	w)
-		WORKFLOWPOOL=$OPTARG
-		;;
-	t)
-		WAIT_TIME=$OPTARG
-		;;
-	l)
-		AINODE_NODEGROUP_LABEL=$OPTARG
-		;;
-	*)
-		echo "Unsupported flag provided : $OPTARG".
-		help
-		exit 1
-		;;
-	esac
+  case "$opt" in
+  h)
+    help
+    exit 0
+    ;;
+  n)
+    NAMESPACE=$OPTARG
+    ;;
+  w)
+    WORKFLOWPOOL=$OPTARG
+    ;;
+  t)
+    WAIT_TIME=$OPTARG
+    ;;
+  l)
+    AINODE_NODEGROUP_LABEL=$OPTARG
+    ;;
+  *)
+    echo "Unsupported flag provided : $OPTARG".
+    help
+    exit 1
+    ;;
+  esac
 done
 
 if [ "$NAMESPACE" == "" ]; then
-	echo "Namespace was not specified, aborting"
-	exit 1
+  echo "Namespace was not specified, aborting"
+  exit 1
 fi
 
 if [ "$WORKFLOWPOOL" == "" ]; then
-	echo "WorkflowPool was not specified, aborting"
-	exit 1
+  echo "WorkflowPool was not specified, aborting"
+  exit 1
 fi
 
 if [ "$(kubectl get namespace ${NAMESPACE})" == "" ]; then
-	echo "Namespace ${NAMESPACE} does not exist, exiting."
-	exit 1
+  echo "Namespace ${NAMESPACE} does not exist, exiting."
+  exit 1
 fi
 
 echo -e "${GREEN}Cordon all ainode nodes ${NORMAL}"
@@ -108,21 +106,21 @@ kubectl cordon -l ${AINODE_NODEGROUP_LABEL}
 
 # Reconciles ainodes in provider order
 echo -e "${GREEN}Starting restart of all ainodes...${NORMAL}"
-for ainode in "${AINODE_BATCH[@]}"; do
-	name=$(echo "${ainode}" | cut -d "," -f 1)
-	kind=$(echo "${ainode}" | cut -d "," -f 2)
-	wait=$(echo "${ainode}" | cut -d "," -f 3)
-	changed="false"
+for deploy in "${BATCH[@]}"; do
+  name=$(echo "${deploy}" | cut -d "," -f 1)
+  type=$(echo "${deploy}" | cut -d "," -f 2)
+  kind=$(echo "${deploy}" | cut -d "," -f 3)
+  wait=$(echo "${deploy}" | cut -d "," -f 4)
 
-	echo -e "${GREEN}Reconciling ainode ${name} ${NORMAL}"
-	kubectl rollout restart ${kind}/${WORKFLOWPOOL}-${name}-ainode -n "${NAMESPACE}"
+  echo -e "${GREEN}Rescheduling deployment ${name} ${NORMAL}"
+  kubectl rollout restart ${kind}/${WORKFLOWPOOL}-${name}${type} -n "${NAMESPACE}"
 
-	# Wait for rollout to be completed
-	echo -e "${GREEN}Waiting for rollout to be complete ${NORMAL}"
-	kubectl rollout status "${kind}" "${WORKFLOWPOOL}-${name}-ainode" -n "${NAMESPACE}"
+  # Wait for rollout to be completed
+  echo -e "${GREEN}Waiting for rollout to be complete ${NORMAL}"
+  kubectl rollout status "${kind}" "${WORKFLOWPOOL}-${name}${type}" -n "${NAMESPACE}"
 
-	if [[ $wait == "true" ]]; then
-		echo -e "${YELLOW}Ainode needs to populate cache, waiting ${WAIT_TIME} seconds ${NORMAL}"
-		sleep "${WAIT_TIME}"
-	fi
+  if [[ $wait == "true" ]]; then
+    echo -e "${YELLOW}Ainode needs to populate cache, waiting ${WAIT_TIME} seconds ${NORMAL}"
+    sleep "${WAIT_TIME}"
+  fi
 done

--- a/roll.sh
+++ b/roll.sh
@@ -5,6 +5,11 @@ set -eu pipeline
 OVERPROVISIONER_NAMESPACE=cluster-overprovisioner
 OVERPROVISIONER_DEPLOYMENT=cluster-overprovisioner-captures-overprovisioner
 CAPTURE_NAMESPACE=reference
+CAPTURE_IMAGE=$(
+  kubectl get deployment -n reference -o json |
+    jq -r '.items[] | select(.metadata.name | endswith("capture")) | .spec.template.spec.containers[0].image' |
+    head -1
+)
 
 # Colors
 end="\033[0m"
@@ -60,7 +65,7 @@ function fail_and_exit {
 
 function drain {
   yellow "Draining $1"
-  kubectl drain $1 --ignore-daemonsets=true --delete-emptydir-data=true --timeout=120s
+  kubectl drain $1 --ignore-daemonsets=true --delete-emptydir-data=true --timeout=120s --skip-wait-for-delete-timeout=1
   green "$1 successfully drained."
 }
 
@@ -84,11 +89,9 @@ function kubestatic_unlabel {
 function check_capture_status {
   echo -n "No capture pod should be pending, checking... "
   for status in $(kubectl -n $CAPTURE_NAMESPACE get pods \
-                  -l app.kubernetes.io/name=capture -o json | \
-                  jq -r .items[].status.phase)
-  do
-    if [[ ${status} != "Running" ]]
-    then
+    -l app.kubernetes.io/name=capture -o json |
+    jq -r .items[].status.phase); do
+    if [[ ${status} != "Running" ]]; then
       fail_and_exit "All capture pods are not in a Running state, I can't continue."
     fi
   done
@@ -98,39 +101,91 @@ function check_capture_status {
 function check_overprovisioner_status {
   echo -n "No capture overprovisioner should be pending, checking... "
   for status in $(kubectl get -n $OVERPROVISIONER_NAMESPACE pods \
-                  -l app.cluster-overprovisioner/deployment=captures-overprovisioner -o json \
-                  | jq -r .items[].status.phase)
-  do
-    if [[ ${status} != "Running" ]]
-    then
-      fail_and_exit "All overprovisioner pods are not in a Running state, I can't continue."
+    -l app.cluster-overprovisioner/deployment=captures-overprovisioner -o json |
+    jq -r .items[].status.phase); do
+    if [[ ${status} == "Pending" ]]; then
+      fail_and_exit "Some overprovisioner pods are in a Pending state, I can't continue."
     fi
   done
   echo -e "${green}Ok${end}"
 }
+
+function disable_unschedulable_ipassign {
+  green "Make sure unschedulable node can not receive IP"
+  local unschedulable_nodes=$(
+    kubectl get nodes -l group=captures-fix-group -o json |
+      jq -r '.items[] | select(.spec.unschedulable = true) | .metadata.name'
+  )
+
+  for node in ${unschedulable_nodes}; do
+    kubestatic_unlabel $node
+  done
+}
+
+function cordon_all {
+  green "First, cordon all schedulable capture nodes.."
+  nodes=$(
+    kubectl get nodes -l group=captures-fix-group -o json |
+      jq -r '.items[] | select(.spec.unschedulable != true) | .metadata.name'
+  )
+
+  for node in ${nodes}; do
+    kubectl cordon ${node}
+  done
+}
+
+function check_OP_image {
+  echo -n "Capture overprovisioner image should match capture pod, checking... "
+  OP_IMAGE=$(
+    kubectl get deployment -n ${OVERPROVISIONER_NAMESPACE} ${OVERPROVISIONER_DEPLOYMENT} -o json |
+      jq -r .spec.template.spec.containers[0].image
+  )
+
+  [[ ${OP_IMAGE} == ${CAPTURE_IMAGE} ]] || fail_and_exit "You must set capture overprovisioner image as the capture pod."
+  echo -e "${green}Ok${end}"
+}
+
+function check_OP_GCR_secret {
+  echo -n "Capture overprovisioner should have a secret and reference it to access GCR capture image, checking... "
+  kubectl get secret -n ${OVERPROVISIONER_NAMESPACE} quortex-gcr > /dev/null 2>&1 || fail_and_exit "quortex-gcr secret is missing in namespace ${OVERPROVISIONER_NAMESPACE}"
+
+  # check OP has a imagePullSecret block that points to existing secret
+  OP_DEPLOY_SECRET_NAME=$(
+    kubectl get deployment -n ${OVERPROVISIONER_NAMESPACE} ${OVERPROVISIONER_DEPLOYMENT} -o json |
+      jq -r .spec.template.spec.imagePullSecrets[0].name 2>/dev/null
+  )
+  [[ ${OP_DEPLOY_SECRET_NAME} != "quortex-gcr" ]] && fail_and_exit "You must set the GCR image pull secret in capture overprovisioner deployment."
+
+  echo -e "${green}Ok${end}"
+}
+
+function now {
+  date +%s
+}
+
 [[ ! $(which kubectl) ]] && fail_and_exit "kubectl CLI not found"
 
 check_capture_status
+check_OP_image
+check_OP_GCR_secret
 check_overprovisioner_status
 white "Note that unschedulable capture nodes will be ignored."
-echo; echo
-whiteb "context:     $(kubectl config current-context)"
+echo
+echo
+whiteb "Capture overprovisioner deployment : ${OVERPROVISIONER_DEPLOYMENT}"
+whiteb "Capture overprovisioner namespace  : ${OVERPROVISIONER_NAMESPACE}"
+whiteb "Capture image                      : ${CAPTURE_IMAGE}"
+whiteb "Kube context                       : $(kubectl config current-context)"
 echo -n "Continue? y/n "
 read answer
 
-if [[ $answer != "y" ]];
-then
+if [[ $answer != "y" ]]; then
   fail_and_exit "Did not receive [y], exiting."
 fi
 
-green "First, cordon all schedulable capture nodes.."
-nodes=$(
-  kubectl get nodes -l group=captures-fix-group -o json |
-    jq -r '.items[] | select(.spec.unschedulable != true) | .metadata.name'
-)
-for node in ${nodes}; do
-  kubectl cordon ${node}
-done
+disable_unschedulable_ipassign
+cordon_all
+#update_OP_image
 
 # First rollout overprovisioner nodes
 OP_nodesName=$(
@@ -142,7 +197,6 @@ green "Draining all nodes with overprovisioner"
 for node in $OP_nodesName; do
   yellow "Draining ${node}"
   kubectl drain ${node} --ignore-daemonsets=true --delete-emptydir-data=true --force --timeout=120s
-  green "Draining ${node} successful"
 done
 
 OP_podsName=$(
@@ -152,8 +206,24 @@ OP_podsName=$(
 )
 
 green "Wait for capture overprovisioners to reschedule..."
+TIMEOUT=300
 for pod in $OP_podsName; do
-  kubectl wait -n ${OVERPROVISIONER_NAMESPACE} --for=condition=ready ${pod} --timeout=300s
+  nodeName=null
+  while [[ $nodeName == "null" ]]; do
+    echo "nodename=$nodeName, waiting."
+    # If nodeName is non-null then we consider it to be acceptable
+    nodeName=$(
+      kubectl get -n ${OVERPROVISIONER_NAMESPACE} ${pod} -o json |
+        jq -r .spec.nodeName
+    )
+    sleep 1
+
+    TIMEOUT=$((TIMEOUT - 1))
+    if [[ $TIMEOUT -lt 0 ]]; then
+      fail_and_exit capture overprovisioner never scheduled.
+    fi
+  done
+  white "$pod is scheduled."
 done
 
 for node in ${nodes}; do
@@ -167,12 +237,6 @@ for node in ${nodes}; do
 
   white "Working on ${node}"
 
-  # Drain capture node
-  start_downtime=`date +%s`
-  drain $node
-  kubestatic_unlabel $node
-  releaseip $node
-
   # Make an OP node (any of them) available for capture pods
   OP_nodeName=$(
     kubectl get pod -n cluster-overprovisioner \
@@ -180,9 +244,35 @@ for node in ${nodes}; do
       -o json |
       jq -r .items[0].spec.nodeName
   )
+
+  # Start capture migration
+  start_downtime=$(now)
+  kubestatic_unlabel $node
+  yellow "==> Unlabeling capture node took $(($(now) - start_downtime))s."
+  stamp=$(now)
+
   green "Free $OP_nodeName overprovisioner node"
   kubectl uncordon $OP_nodeName
+  yellow "==> Making overprovisioner node schedulable took $(($(now) - stamp))s."
+  stamp=$(now)
+
+  releaseip $node
+  yellow "==> Release EIP from capture node took $(($(now) - stamp))s."
+  stamp=$(now)
+
+  for pod in ${capture_pods}; do
+    kubectl delete pod --force=true -n ${CAPTURE_NAMESPACE} ${pod}
+    yellow "==> Force deleted pod ${pod} in $(($(now) - stamp))s."
+    stamp=$(now)
+  done
+
   releaseip $OP_nodeName
+  yellow "==> Release EIP from overprovisioner node took $(($(now) - stamp))s."
+  stamp=$(now)
+
+  drain $node
+  yellow "==> Draining took $(($(now) - start_downtime))s."
+  stamp=$(now)
 
   # wait for capture pods to be scheduled on new node
   pending_capture_pods=$(
@@ -193,8 +283,9 @@ for node in ${nodes}; do
     green "Waiting for $pod to be scheduled..."
     kubectl wait -n $CAPTURE_NAMESPACE --for=condition=ready pod ${pod} --timeout=300s
   done
-  end_downtime=`date +%s`
-  yellowb "==> capture pods on ${node} were unavailable for $((end_downtime-start_downtime)) seconds."
+  yellow "==> Waiting for capture pod to be ready took $(($(now) - stamp))s."
+  end_downtime=$(date +%s)
+  yellowb "==> capture pods on ${node} were unavailable for $((end_downtime - start_downtime)) seconds."
 
   # wait for OP pods to be scheduled
   OP_podsName=$(
@@ -205,6 +296,22 @@ for node in ${nodes}; do
   green "Wait for overprovisioners to be rescheduled too"
   for pod in ${OP_podsName}; do
     green "Waiting for ${pod} to be scheduled..."
-    kubectl wait -n ${OVERPROVISIONER_NAMESPACE} --for=condition=ready ${pod} --timeout=300s
+    nodeName=null
+    while [[ $nodeName == "null" ]]; do
+      # If nodeName is non-null then we consider it to be acceptable
+      nodeName=$(
+        kubectl get -n ${OVERPROVISIONER_NAMESPACE} ${pod} -o json |
+          jq -r .spec.nodeName
+      )
+      sleep 1
+
+      TIMEOUT=$((TIMEOUT - 1))
+
+      if [[ $TIMEOUT -lt 0 ]]; then
+        fail_and_exit capture overprovisioner never scheduled.
+      fi
+
+    done
+    white "$pod is scheduled."
   done
 done

--- a/roll.sh
+++ b/roll.sh
@@ -1,0 +1,177 @@
+#!/bin/bash
+
+set -eu pipeline
+
+OVERPROVISIONER_NAMESPACE=cluster-overprovisioner
+OVERPROVISIONER_DEPLOYMENT=cluster-overprovisioner-captures-overprovisioner
+CAPTURE_NAMESPACE=reference
+#KUBESTATIC_NAMESPACE=kubestatic-system
+#KUBESTATIC_DEPLOYMENT=kubestatic
+
+# Colors
+end="\033[0m"
+black="\033[0;30m"
+blackb="\033[1;30m"
+white="\033[0;37m"
+whiteb="\033[1;37m"
+red="\033[0;31m"
+redb="\033[1;31m"
+green="\033[0;32m"
+greenb="\033[1;32m"
+yellow="\033[0;33m"
+yellowb="\033[1;33m"
+blue="\033[0;34m"
+blueb="\033[1;34m"
+purple="\033[0;35m"
+purpleb="\033[1;35m"
+lightblue="\033[0;36m"
+lightblueb="\033[1;36m"
+
+function green {
+	echo -e "${green}${1}${end}"
+}
+
+function greenb {
+	echo -e "${greenb}${1}${end}"
+}
+
+function white {
+	echo -e "${white}${1}${end}"
+}
+
+function whiteb {
+	echo -e "${whiteb}${1}${end}"
+}
+
+function yellow {
+	echo -e "${yellow}${1}${end}"
+}
+
+function redb {
+	echo -e "${redb}${1}${end}"
+}
+
+function fail_and_exit {
+	redb "$1"
+	exit 1
+}
+
+function drain {
+	yellow "Draining $1"
+	kubectl drain $1 --ignore-daemonsets=true --delete-emptydir-data=true --timeout=120s
+	green "$1 successfully drained."
+}
+
+function releaseip {
+	externalip_name=$(
+		kubectl get externalips -o json |
+			jq -r --arg n $1 '.items[] | select(.spec.nodeName == $n) | .metadata.name'
+	)
+
+	for ip in $externalip_name; do
+		green "Disassociate EIP $ip from $1"
+		kubectl patch externalips $ip --type=merge -p '{"spec": {"nodeName": ""}}'
+	done
+}
+
+function kubestatic_unlabel {
+	green "Remove kubestatic label on node $1"
+	kubectl label node $1 kubestatic.quortex.io/externalip-auto-assign-
+}
+
+[[ ! $(which kubectl) ]] && fail_and_exit "kubectl CLI not found"
+
+whiteb "No capture pod should be pending"
+whiteb "No capture overprovisioner should be pending"
+echo
+whiteb "context:     $(kubectl config current-context)"
+echo -n "Continue? y/n "
+read answer
+
+if [[ $answer != "y" ]];
+then
+	fail_and_exit "Did not receive [y], exiting."
+fi
+
+green "First, cordon all schedulable capture nodes.."
+nodes=$(
+	kubectl get nodes -l group=captures-fix-group -o json |
+		jq -r '.items[] | select(.spec.unschedulable != true) | .metadata.name'
+)
+for node in ${nodes}; do
+	kubectl cordon ${node}
+done
+
+# First rollout overprovisioner nodes
+OP_nodesName=$(
+	kubectl get pod -n $OVERPROVISIONER_NAMESPACE \
+		-l app.cluster-overprovisioner/deployment=captures-overprovisioner -o json |
+		jq -r .items[].spec.nodeName | uniq
+)
+green "Draining all nodes with overprovisioner"
+for node in $OP_nodesName; do
+	yellow "Draining ${node}"
+	kubectl drain ${node} --ignore-daemonsets=true --delete-emptydir-data=true --force --timeout=120s
+	green "Draining ${node} successful"
+done
+
+OP_podsName=$(
+	kubectl get pod -n $OVERPROVISIONER_NAMESPACE \
+		-l app.cluster-overprovisioner/deployment=captures-overprovisioner \
+		-o name
+)
+
+green "Wait for capture overprovisioners to reschedule..."
+for pod in $OP_podsName; do
+	kubectl wait -n ${OVERPROVISIONER_NAMESPACE} --for=condition=ready ${pod} --timeout=300s
+done
+
+for node in ${nodes}; do
+	# Get some info about the cluster state
+	capture_pods=$(
+		kubectl get pods -A --field-selector spec.nodeName=${node} |
+			grep capture | awk '{print $2}'
+	)
+	# probably only overprovisioner pods on this node, skipping
+	[[ -z $capture_pods ]] && continue
+
+	white "Working on ${node}"
+
+	# Drain capture node
+	drain $node
+	kubestatic_unlabel $node
+	releaseip $node
+
+	# Make an OP node (any of them) available for capture pods
+	OP_nodeName=$(
+		kubectl get pod -n cluster-overprovisioner \
+			-l app.cluster-overprovisioner/deployment=captures-overprovisioner \
+			-o json |
+			jq -r .items[0].spec.nodeName
+	)
+	green "Free $OP_nodeName overprovisioner node"
+	kubectl uncordon $OP_nodeName
+	releaseip $OP_nodeName
+
+	# wait for capture pods to be scheduled on new node
+	pending_capture_pods=$(
+		kubectl get pods -n $CAPTURE_NAMESPACE -o json |
+			jq -r '.items[] | select(.status.phase == "Pending") | .metadata.name'
+	)
+	for pod in $pending_capture_pods; do
+		green "Waiting for $pod to be scheduled..."
+		kubectl wait -n $CAPTURE_NAMESPACE --for=condition=ready pod ${pod} --timeout=300s
+	done
+
+	# wait for OP pods to be scheduled
+	OP_podsName=$(
+		kubectl get pod -n ${OVERPROVISIONER_NAMESPACE} \
+			-l app.cluster-overprovisioner/deployment=captures-overprovisioner \
+			-o name
+	)
+	green "Wait for overprovisioners to be rescheduled too"
+	for pod in ${OP_podsName}; do
+		green "Waiting for ${pod} to be scheduled..."
+		kubectl wait -n ${OVERPROVISIONER_NAMESPACE} --for=condition=ready ${pod} --timeout=300s
+	done
+done

--- a/rtmp_checker.sh
+++ b/rtmp_checker.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+# This script will connect to all RTMP handler pods and output the
+# Input name. This may be useful if you want to make sure multiple
+# streams from a single groupID are not on the same handler.
+
+set -eu pipeline
+
+HANDLER_NAMESPACE=reference
+
+# Colors
+end="\033[0m"
+black="\033[0;30m"
+blackb="\033[1;30m"
+white="\033[0;37m"
+whiteb="\033[1;37m"
+red="\033[0;31m"
+redb="\033[1;31m"
+green="\033[0;32m"
+greenb="\033[1;32m"
+yellow="\033[0;33m"
+yellowb="\033[1;33m"
+blue="\033[0;34m"
+blueb="\033[1;34m"
+purple="\033[0;35m"
+purpleb="\033[1;35m"
+lightblue="\033[0;36m"
+lightblueb="\033[1;36m"
+
+function green {
+	echo -e "${green}${1}${end}"
+}
+
+function greenb {
+	echo -e "${greenb}${1}${end}"
+}
+
+function white {
+	echo -e "${white}${1}${end}"
+}
+
+function whiteb {
+	echo -e "${whiteb}${1}${end}"
+}
+
+function yellow {
+	echo -e "${yellow}${1}${end}"
+}
+
+function redb {
+	echo -e "${redb}${1}${end}"
+}
+
+function fail_and_exit {
+	redb "$1"
+	exit 1
+}
+
+function get_input_name_from_stream {
+	kubectl get streams -n ${HANDLER_NAMESPACE} -o json |
+		jq -r --arg key $1 '.items[] | select(.spec.streamKey == $key) | .metadata.name'
+}
+
+[[ ! $(which kubectl) ]] && fail_and_exit "kubectl CLI not found"
+
+whiteb "context:     $(kubectl config current-context)"
+echo -n "Continue? y/n "
+read answer
+
+if [[ $answer != "y" ]];
+then
+	fail_and_exit "Did not receive [y], exiting."
+fi
+
+handlers=$(kubectl get pods -n ${HANDLER_NAMESPACE} -l app.kubernetes.io/name=rtmp-handler -o name)
+
+for handler in $handlers; do
+	kubectl -n ${HANDLER_NAMESPACE} port-forward ${handler} 8082:8080 > /dev/null 2>&1 &
+	sleep 2
+
+	handled_streams=$(curl -s http://localhost:8082/streams | jq -r .[])
+	[[ -n ${handled_streams} ]] && \
+		green "${handler} handles streams [${handled_streams}]" || \
+		yellow "${handler} does not handle any stream"
+	for key in ${handled_streams}; do
+		input_name=$(
+			kubectl get streams -n ${HANDLER_NAMESPACE} -o json |
+				jq -r --arg k $key '.items[] | select(.spec.streamKey == $k) | .metadata.name'
+		)
+		white "${handler} -> input : ${input_name}"
+	done
+
+	pid=$(jobs -l -p)
+	kill ${pid}
+
+	sleep 1
+done


### PR DESCRIPTION
3 scripts :
- roll.sh will help rescheduling capture pods on new nodes.
- reschedule_ainode.sh will reschedule all ainodes/backend/shield/traefik/Mongodb pod on new nodes, and wait for cache to populate before moving to next pod.
- rtmp_checker.sh is a simple script that will list all input and associated handler. To make sure 2 input for same groupId aren't scheduled on same handler.
