### PR TITLE
Simplify azure init script

### DIFF
--- a/init_tf_backend_azure.sh
+++ b/init_tf_backend_azure.sh
@@ -10,7 +10,6 @@
 set -euo pipefail
 
 RESOURCE_GROUP_NAME=administration
-SUBSCRIPTION=
 
 function help() {
     cat <<EOF
@@ -22,9 +21,8 @@ Mandatory arguments :
     -a         The name of Storage Account.
     -c         The name of Storage Container.
 Available options :
-    -s          The name of the subscription.
     -r         The name of Ressource Group (default $RESOURCE_GROUP_NAME).
-    -h           Display this help.
+    -h         Display this help.
 EOF
 }
 
@@ -43,9 +41,6 @@ while getopts "h:r:a:c:s" opt; do
     c)
         CONTAINER_NAME=$OPTARG
         ;;
-    s)
-        SUBSCRIPTION=$OPTARG
-        ;;
     *)
         echo "Unsupported flag provided : ${OPTARG}".
         help
@@ -59,12 +54,7 @@ if [ "$NAME" == "" ]; then
     exit 1
 fi
 
-if [ "$SUBSCRIPTION" == "" ]; then
-    echo "Subscription not specified, the subscription is the default sub of the account."
-    SUBSCRIPTION=$(az account list --query "[?isDefault].id | [0]" -o tsv)
-fi
-
-export AZURE_extension_use_dynamic_install=yes_without_prompt
+export AZURE_EXTENSION_USE_DYNAMIC_INSTALL=yes_without_prompt
 
 # Create Storage Account
 echo "Creating storage account : ${STORAGE_ACCOUNT_NAME}"

--- a/init_tf_backend_azure.sh
+++ b/init_tf_backend_azure.sh
@@ -9,8 +9,6 @@
 # Bash strict mode
 set -euo pipefail
 
-REGION=westeurope
-NAME=
 RESOURCE_GROUP_NAME=administration
 SUBSCRIPTION=
 
@@ -18,45 +16,41 @@ function help() {
     cat <<EOF
 Provision the resources needed to store terraform states on Azure.
 A storage account is created and container for store state.
-Usage : $0 -n NAME [options]
+Usage : $0 -a STORAGE_ACCOUNT -c STORAGE_CONTAINER [options]
 
 Mandatory arguments :
-    -n NAME      Set the name of created resources.
+    -a         The name of Storage Account.
+    -c         The name of Storage Container.
 Available options :
-    -r          The name of the region (default $REGION).
     -s          The name of the subscription.
-    -rg         The name of Ressource Group (default $RESOURCE_GROUP_NAME).
-    -st         The name of Storage Account.
-    -ct         The name of Container.
+    -r         The name of Ressource Group (default $RESOURCE_GROUP_NAME).
     -h           Display this help.
 EOF
 }
 
-while getopts "n:s:r:h:rg:st:ct" opt; do
+while getopts "h:r:a:c:s" opt; do
     case "$opt" in
     h)
         help
         exit 0
         ;;
     r)
-        REGION=$OPTARG
-        ;;
-    n)
-        NAME=$OPTARG
-        ;;
-    rg)
         RESOURCE_GROUP_NAME=$OPTARG
         ;;
-    st) 
+    a)
         STORAGE_ACCOUNT_NAME=$OPTARG
         ;;
-    ct)
+    c)
         CONTAINER_NAME=$OPTARG
         ;;
     s)
         SUBSCRIPTION=$OPTARG
         ;;
-
+    *)
+        echo "Unsupported flag provided : ${OPTARG}".
+        help
+        exit 1
+        ;;
     esac
 done
 
@@ -70,20 +64,19 @@ if [ "$SUBSCRIPTION" == "" ]; then
     SUBSCRIPTION=$(az account list --query "[?isDefault].id | [0]" -o tsv)
 fi
 
-#Set var with name input
-STORAGE_ACCOUNT_NAME=${NAME}staccount
-CONTAINER_NAME=tfstate${STORAGE_ACCOUNT_NAME}
-
 export AZURE_extension_use_dynamic_install=yes_without_prompt
-user=$(az ad signed-in-user show --query userPrincipalName --output tsv)
 
 # Create Storage Account
-echo "Creating storage account : ${RESOURCE_GROUP_NAME}"
-res=$(az storage account create --resource-group $RESOURCE_GROUP_NAME --name $STORAGE_ACCOUNT_NAME --sku Standard_LRS --encryption-services blob)
+echo "Creating storage account : ${STORAGE_ACCOUNT_NAME}"
+az storage account create \
+    --name "${STORAGE_ACCOUNT_NAME}" \
+    --resource-group "${RESOURCE_GROUP_NAME}" \
+    --sku Standard_LRS \
+    --encryption-services blob
 
-echo "Creating Storage Account : ${RESOURCE_GROUP_NAME}"
 # Create Storage Account Container
-res=$(az storage container create --name $CONTAINER_NAME --account-name $STORAGE_ACCOUNT_NAME --auth-mode login)
-
-echo "storage_account_name: $STORAGE_ACCOUNT_NAME"
-echo "container_name: $CONTAINER_NAME"
+echo "Creating Storage Account : ${CONTAINER_NAME}"
+az storage container create \
+    --name "${CONTAINER_NAME}" \
+    --account-name "${STORAGE_ACCOUNT_NAME}" \
+    --auth-mode login

--- a/init_tf_backend_azure.sh
+++ b/init_tf_backend_azure.sh
@@ -39,18 +39,23 @@ while getopts "h:r:a:c:s" opt; do
         STORAGE_ACCOUNT_NAME=$OPTARG
         ;;
     c)
-        CONTAINER_NAME=$OPTARG
+        STORAGE_CONTAINER_NAME=$OPTARG
         ;;
     *)
-        echo "Unsupported flag provided : ${OPTARG}".
+        echo "Unsupported flag provided : ${opt}".
         help
         exit 1
         ;;
     esac
 done
 
-if [ "$NAME" == "" ]; then
-    echo "Name was not specified, aborting !"
+if [ "$STORAGE_ACCOUNT_NAME" == "" ]; then
+    echo "Storage account name was not specified, aborting !"
+    exit 1
+fi
+
+if [ "$STORAGE_CONTAINER_NAME" == "" ]; then
+    echo "Storage container name was not specified, aborting !"
     exit 1
 fi
 
@@ -62,11 +67,13 @@ az storage account create \
     --name "${STORAGE_ACCOUNT_NAME}" \
     --resource-group "${RESOURCE_GROUP_NAME}" \
     --sku Standard_LRS \
-    --encryption-services blob
+    --encryption-services blob \
+    --output none
 
 # Create Storage Account Container
-echo "Creating Storage Account : ${CONTAINER_NAME}"
+echo "Creating Storage Account : ${STORAGE_CONTAINER_NAME}"
 az storage container create \
-    --name "${CONTAINER_NAME}" \
+    --name "${STORAGE_CONTAINER_NAME}" \
     --account-name "${STORAGE_ACCOUNT_NAME}" \
-    --auth-mode login
+    --auth-mode login \
+    --output none


### PR DESCRIPTION
This PR removes strange automatic naming of account and container. 
It also clean up the command line arguments (⚠️ small breaking change).

Should not I also remove the SUBSCRIPTION related part ? 
From what I read, it is not used and [do not seems to have an effect as environment variable](https://learn.microsoft.com/en-us/cli/azure/azure-cli-configuration#cli-configuration-values-and-environment-variables).