### PR TITLE
feat: make init_tf_backend_aws clearer

### DIFF
--- a/init_tf_backend_aws.sh
+++ b/init_tf_backend_aws.sh
@@ -77,14 +77,16 @@ if [ "$PREFIXED" == true ]; then
 fi
 
 if [ "$INTERACTIVE" == true ]; then
-    echo "This will create an s3 bucket and optionally a DynamoDB table named $NAME"
-    echo "In region $REGION"
-    echo ""
-    read -p "Continue (y/n)?" CONT
-    if [ "$CONT" != "y" ]; then
-        echo "Aborting !";
-        exit 0
+    PLAN="This will create a S3 bucket"
+    if [ "$CREATE_DYNAMODB" == true ]; then
+        PLAN="$PLAN and a DynamoDB table"
     fi
+	echo "$PLAN named ${NAME} in region ${REGION}."
+	read -p "Continue (y/n)?" CONT
+	if [ "$CONT" != "y" ]; then
+		echo "Aborting !"
+		exit 0
+	fi
 fi
 
 # Management of the creation of the s3 bucket.


### PR DESCRIPTION
Instead of always printing: 
```
This will create an s3 bucket and optionally a DynamoDB table named 230480795310-tfstate-platform-prod-dataplane-saas-staging-eu-west-1-02
In region eu-west-1
```

This will print: 
* If dynamo is disabled:
  ```
  This will create a S3 bucket named 230480795310-tfstate-platform-prod-dataplane-saas-staging-eu-west-1-02 in region eu-west-1.
  Continue (y/n)?
  ```
* If dynamo is enabled:
  ```
  This will create a S3 bucket and a DynamoDB table named 230480795310-tfstate-platform-prod-dataplane-saas-staging-eu-west-1-02 in region eu-west-1.
  Continue (y/n)?
  ```